### PR TITLE
Add several most needed wallet rpc methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,10 @@ Wallet.getbalance() |> Monero.request!(config) #=> response
 Monero has by default the equivalent including the following in your mix.exs
 
 ```elixir
-config :monero,
-  wallet: %{
-    wallet: %{
-      url: {:system, "MONERO_WALLET_RPC_URL"},
-      user: {:system, "MONERO_WALLET_RPC_USER"},
-      pasword: {:system, "MONERO_WALLET_RPC_PASSWORD"}
-    }
-  }
+config :monero, wallet:
+  url: {:system, "MONERO_WALLET_RPC_URL"},
+  user: {:system, "MONERO_WALLET_RPC_USER"},
+  password: {:system, "MONERO_WALLET_RPC_PASSWORD"}
 ```
 
 This means values from  `MONERO_WALLET_RPC_URL`, `MONERO_WALLET_RPC_USER` and `MONERO_WALLET_RPC_PASSWORD` environment

--- a/lib/monero/json/jsx.ex
+++ b/lib/monero/json/jsx.ex
@@ -5,7 +5,7 @@ defmodule Monero.JSON.JSX do
 
   if Code.ensure_loaded?(:jsx) do
     def encode!(%{} = map) do
-      :jsx.encode(map )
+      :jsx.encode(map)
     end
 
     def decode!(string) do
@@ -22,18 +22,14 @@ defmodule Monero.JSON.JSX do
   end
 
   def encode(map) do
-    try do
-      {:ok, encode!(map)}
-    rescue
-      ArgumentError -> {:error, :badarg}
-    end
+    {:ok, encode!(map)}
+  rescue
+    ArgumentError -> {:error, :badarg}
   end
 
   def decode(string) do
-    try do
-      {:ok, decode!(string)}
-    rescue
-      ArgumentError -> {:error, :badarg}
-    end
+    {:ok, decode!(string)}
+  rescue
+    ArgumentError -> {:error, :badarg}
   end
 end

--- a/lib/monero/request.ex
+++ b/lib/monero/request.ex
@@ -14,9 +14,9 @@ defmodule Monero.Request do
   @doc "Fire a request. Not inteded to be called by the user, see `Monero.request`"
   def request(http_method, url, data, headers, config, service) do
     body = case data do
-      []  -> "{}"
+      [] -> "{}"
       d when is_binary(d) -> d
-      _   -> config[:json_codec].encode!(data)
+      _ -> config[:json_codec].encode!(data)
     end
 
     request_and_retry(http_method, url, service, config, headers, body, {:attempt, 1})
@@ -25,40 +25,28 @@ defmodule Monero.Request do
   defp request_and_retry(_method, _url, _service, _config, _headers, _req_body, {:error, reason}), do: {:error, reason}
 
   defp request_and_retry(method, url, service, config, headers, req_body, {:attempt, attempt}) do
-    url = replace_spaces(url)
+    url = URI.encode(url)
+    opts = Map.get(config, :http_opts, [])
+    debug_requests(config, url, headers, req_body)
 
-    if config[:debug_requests] do
-      Logger.debug fn ->
-        """
-        Request URL: #{inspect url}"
-        Request HEADERS: #{inspect headers}
-        Request BODY: #{inspect req_body}"
-        """
-      end
-    end
-
-    case config[:http_client].request(method, url, req_body, headers, Map.get(config, :http_opts, [])) do
+    case config[:http_client].request(method, url, req_body, headers, opts) do
       {:ok, response = %{status_code: status}} when status in 200..299 ->
         {:ok, response}
+
       {:ok, %{status_code: status, headers: resp_headers} = resp} when status == 401 ->
         reason = client_error(resp)
-        case  attempt_again?(attempt, reason, config) do
-          {:attempt, attempt} ->
-            with {:ok, full_headers} <- Monero.Auth.headers(method, url, config, resp_headers, headers) do
-              request_and_retry(method, url, service, config, full_headers, req_body, {:attempt, attempt})
-            end
-          {:error, reason} -> {:error, reason}
-        end
-      {:ok, %{status_code: status} = resp} when status in 400..499 ->
+        with {:attempt, attempt} <- attempt_again?(attempt, reason, config),
+             {:ok, full_headers} <- Monero.Auth.headers(method, url, config, resp_headers, headers),
+             do: request_and_retry(method, url, service, config, full_headers, req_body, {:attempt, attempt})
+
+      {:ok, %{status_code: status} = resp} when status in 400..499 and status != 401 ->
         reason = client_error(resp)
-        case  attempt_again?(attempt, reason, config) do
-          {:attempt, reason} ->
-            request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
-          {:error, reason} -> {:error, reason}
-        end
+        request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
+
       {:ok, %{status_code: status, body: body}} when status >= 500 ->
         reason = {:http_error, status, body}
         request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
+
       {:error, %{reason: reason}} ->
         Logger.warn("Monero: HTTP ERROR: #{inspect reason}")
         request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
@@ -86,7 +74,15 @@ defmodule Monero.Request do
     |> :timer.sleep
   end
 
-  defp replace_spaces(url) do
-    String.replace(url, " ", "%20")
+  defp debug_requests(config, url, headers, body) do
+    if config[:debug_requests] do
+      Logger.debug fn ->
+        """
+        Request URL: #{inspect url}"
+        Request HEADERS: #{inspect headers}
+        Request BODY: #{inspect body}"
+        """
+      end
+    end
   end
 end

--- a/lib/monero/request.ex
+++ b/lib/monero/request.ex
@@ -39,7 +39,7 @@ defmodule Monero.Request do
              {:ok, full_headers} <- Monero.Auth.headers(method, url, config, resp_headers, headers),
              do: request_and_retry(method, url, service, config, full_headers, req_body, {:attempt, attempt})
 
-      {:ok, %{status_code: status} = resp} when status in 400..499 and status != 401 ->
+      {:ok, %{status_code: status} = resp} when status in 400..499 ->
         reason = client_error(resp)
         request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
 

--- a/lib/monero/wallet.ex
+++ b/lib/monero/wallet.ex
@@ -10,6 +10,62 @@ defmodule Monero.Wallet do
     request("getbalance")
   end
 
+  @doc "Return the wallet's address."
+  @spec getaddress() :: Monero.Operation.Query.t
+  def getaddress() do
+    request("getaddress")
+  end
+
+  @doc """
+  Get a list of incoming payments using a given payment id.
+
+  Args:
+  * `payment_id` - Payment id of incoming payments.
+  """
+  @spec get_payments(String.t) :: Monero.Operation.Query.t
+  def get_payments(payment_id) do
+    request("get_payments", %{payment_id: payment_id})
+  end
+
+  @doc """
+  Return a list of incoming transfers to the wallet.
+
+  Args:
+  * `transfer_type` - `"all"` for all the transfers, `"available"` for only transfers
+  which are not yet spent, or `"unavailable"` for only transfers which are already spent.
+  """
+  @spec incoming_transfers(Strint.t) :: Monero.Operation.Query.t
+  def incoming_transfers(transfer_type) do
+    request("incoming_transfers", %{transfer_type: transfer_type})
+  end
+
+  @doc """
+  Create a new wallet. You need to have set the argument `–wallet-dir` when
+  launching monero-wallet-rpc to make this work.
+
+  Args:
+  * `filename` - Filename for your wallet
+  * `password` - Password for your wallet.
+  * `language` - Language for your wallets' seed.
+  """
+  @spec create_wallet(Strint.t, Strint.t, Strint.t) :: Monero.Operation.Query.t
+  def create_wallet(filename, password, language) do
+    request("create_wallet", %{filename: filename, password: password, language: language})
+  end
+
+  @doc """
+  Open a wallet. You need to have set the argument `–wallet-dir` when
+  launching monero-wallet-rpc to make this work.
+
+  Args:
+  * `filename` - Filename for your wallet
+  * `password` - Password for your wallet.
+  """
+  @spec open_wallet(Strint.t, Strint.t) :: Monero.Operation.Query.t
+  def open_wallet(filename, password) do
+    request("open_wallet", %{filename: filename, password: password})
+  end
+
   ## Request
   ######################
 

--- a/lib/monero/wallet.ex
+++ b/lib/monero/wallet.ex
@@ -31,8 +31,10 @@ defmodule Monero.Wallet do
   Return a list of incoming transfers to the wallet.
 
   Args:
-  * `transfer_type` - `"all"` for all the transfers, `"available"` for only transfers
-  which are not yet spent, or `"unavailable"` for only transfers which are already spent.
+  * `transfer_type` - may be one of the:
+    * `"all"` - for all the transfers.
+    * `"available"` - for only transfers which are not yet spent.
+    * `"unavailable"` - for only transfers which are already spent.
   """
   @spec incoming_transfers(Strint.t) :: Monero.Operation.Query.t
   def incoming_transfers(transfer_type) do
@@ -40,11 +42,11 @@ defmodule Monero.Wallet do
   end
 
   @doc """
-  Create a new wallet. You need to have set the argument `–wallet-dir` when
+  Create a new wallet. You need to have set the argument `--wallet-dir` when
   launching monero-wallet-rpc to make this work.
 
   Args:
-  * `filename` - Filename for your wallet
+  * `filename` - Filename for your wallet.
   * `password` - Password for your wallet.
   * `language` - Language for your wallets' seed.
   """
@@ -54,11 +56,11 @@ defmodule Monero.Wallet do
   end
 
   @doc """
-  Open a wallet. You need to have set the argument `–wallet-dir` when
+  Open a wallet. You need to have set the argument `--wallet-dir` when
   launching monero-wallet-rpc to make this work.
 
   Args:
-  * `filename` - Filename for your wallet
+  * `filename` - Filename for your wallet.
   * `password` - Password for your wallet.
   """
   @spec open_wallet(Strint.t, Strint.t) :: Monero.Operation.Query.t

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Monero.Mixfile do
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib",]
+  defp elixirc_paths(_),     do: ["lib"]
 
   defp deps do
     [

--- a/test/lib/monero/wallet_test.exs
+++ b/test/lib/monero/wallet_test.exs
@@ -6,8 +6,36 @@ defmodule Monero.WalletTest do
     assert %{path: "/json_rpc", service: :wallet} = Wallet.getbalance()
   end
 
-  test "#getbalance" do
+  test "getbalance/0" do
     expected = %{jsonrpc: "2.0", method: "getbalance", params: nil}
     assert expected == Wallet.getbalance().data
+  end
+
+  test "getaddress/0" do
+    expected = %{jsonrpc: "2.0", method: "getaddress", params: nil}
+    assert expected == Wallet.getaddress().data
+  end
+
+  test "get_payments/1" do
+    params = %{payment_id: "0000000000000000"}
+    expected = %{jsonrpc: "2.0", method: "get_payments", params: params}
+    assert expected == Wallet.get_payments("0000000000000000").data
+  end
+
+  test "incoming_transfers/1" do
+    expected = %{jsonrpc: "2.0", method: "incoming_transfers", params: %{transfer_type: "all"}}
+    assert expected == Wallet.incoming_transfers("all").data
+  end
+
+  test "create_wallet/3" do
+    params = %{filename: "test-wallet", password: "password", language: "English"}
+    expected = %{jsonrpc: "2.0", method: "create_wallet", params: params}
+    assert expected == Wallet.create_wallet("test-wallet", "password", "English").data
+  end
+
+  test "open_wallet/3" do
+    params = %{filename: "test-wallet", password: "password"}
+    expected = %{jsonrpc: "2.0", method: "open_wallet", params: params}
+    assert expected == Wallet.open_wallet("test-wallet", "password").data
   end
 end


### PR DESCRIPTION
Tried to tidy up the `Monero.Request.request_and_retry/7`. And there is a problem with the processing of empty answers for example for `Monero.Wallet.create_wallet/3`, say if it returns `{:ok, nil}` then this is a error, and if `{:ok, %{}}` then all is normal. 
So i think we need to think about it or maybe i'm wrong? 乁( ⁰͡  Ĺ̯ ⁰͡ ) ㄏ