### PR TITLE
Add transfer and sendrawtransaction calls

### DIFF
--- a/lib/monero/daemon.ex
+++ b/lib/monero/daemon.ex
@@ -16,6 +16,17 @@ defmodule Monero.Daemon do
     request("getheight")
   end
 
+  @doc """
+  Broadcast a raw transaction to the network.
+
+  Args:
+  * `tx_hex` - Full transaction information as hexidecimal string.
+  """
+  @spec sendrawtransaction(String.t) :: Monero.Operation.Query.t
+  def sendrawtransaction(tx_hex) do
+    request("sendrawtransaction", %{tx_as_hex: tx_hex})
+  end
+
   ## Request
   ######################
 

--- a/lib/monero/wallet.ex
+++ b/lib/monero/wallet.ex
@@ -68,7 +68,6 @@ defmodule Monero.Wallet do
     request("open_wallet", %{filename: filename, password: password})
   end
 
-
   @type transfer_destination :: %{amount: String.t, address: String.t}
 
   @type transfer_opts :: {:payment_id, String.t}
@@ -98,10 +97,10 @@ defmodule Monero.Wallet do
   """
   @spec transfer([transfer_destination], non_neg_integer, non_neg_integer, transfer_opts) :: Monero.Operation.Query.t
   def transfer(destinations, mixin, unlock_time, opts \\ []) do
-    opts_map = build_opts(opts, [:payment_id, :get_tx_key, :priority, :do_not_relay, :get_tx_hex])
     params =
-      %{destinations: destinations, mixin: mixin, unlock_time: unlock_time}
-      |> Map.merge(opts_map)
+      opts
+      |> build_opts([:payment_id, :get_tx_key, :priority, :do_not_relay, :get_tx_hex])
+      |> Map.merge(%{destinations: destinations, mixin: mixin, unlock_time: unlock_time}, opts_map)
 
     request("transfer", params)
   end

--- a/lib/monero/wallet.ex
+++ b/lib/monero/wallet.ex
@@ -81,17 +81,9 @@ defmodule Monero.Wallet do
 
   Args:
   * `destinations` - List of destinations to receive XMR.
-  * `mixin` - Number of outpouts from the blockchain to mix with (0 means no mixing).
+  * `mixin` - Number of outputs from the blockchain to mix with (0 means no mixing).
   * `unlock_time` - Number of blocks before the monero can be spent (0 to not add a lock)
-  * `payment_id` - (Optional) Random 32-byte/64-character hex string to identify a transaction.
-  * `get_tx_key` - (Optional) Return the transaction key after sending.
-  * `priority` - (Optional) Set a priority for the transaction. Accepted Values are:
-    * `0` - default
-    * `1` - unimportant
-    * `2` - normal
-    * `3` - elevated
-  * `do_not_relay` - (Optional) avoid relaying the transaction to the network.
-  * `get_tx_hex` - (Optional) Return the transaction as hex string after sending
+  * optional arguments in a form of keyword list as described in the documentation
 
   **NOTE:** destination amount is in atomic units, means 1e12 = 1 XMR
   """

--- a/lib/monero/wallet.ex
+++ b/lib/monero/wallet.ex
@@ -81,7 +81,7 @@ defmodule Monero.Wallet do
 
   Args:
   * `destinations` - List of destinations to receive XMR.
-  * `mixin` - Number of outputs from the blockchain to mix with (0 means no mixing).
+  * `mixin` - Number of outputs from the blockchain to mix with.
   * `unlock_time` - Number of blocks before the monero can be spent (0 to not add a lock)
   * optional arguments in a form of keyword list as described in the documentation
 
@@ -92,7 +92,7 @@ defmodule Monero.Wallet do
     params =
       opts
       |> build_opts([:payment_id, :get_tx_key, :priority, :do_not_relay, :get_tx_hex])
-      |> Map.merge(%{destinations: destinations, mixin: mixin, unlock_time: unlock_time}, opts_map)
+      |> Map.merge(%{destinations: destinations, mixin: mixin, unlock_time: unlock_time})
 
     request("transfer", params)
   end

--- a/test/lib/monero/daemon_test.exs
+++ b/test/lib/monero/daemon_test.exs
@@ -6,12 +6,20 @@ defmodule Monero.DaemonTest do
     assert %{path: "/json_rpc", service: :daemon} = Daemon.get_fee_estimate()
   end
 
-  test "#get_fee_estimate" do
+  test "get_fee_estimate/0" do
     expected = %{jsonrpc: "2.0", method: "get_fee_estimate", params: nil}
     assert expected == Daemon.get_fee_estimate().data
   end
 
-    test "#getheight" do
+  test "getheight/0" do
     assert %{action: "getheight", path: "/getheight", data: %{}} = Daemon.getheight()
+  end
+
+  test "sendrawtransaction/1" do
+    tx_hex = "010002028090c...81a2e3bc0039cb0a02"
+
+    assert %{
+      action: "sendrawtransaction", path: "/sendrawtransaction", data: %{tx_as_hex: ^tx_hex}
+    } = Daemon.sendrawtransaction(tx_hex)
   end
 end

--- a/test/lib/monero/wallet_test.exs
+++ b/test/lib/monero/wallet_test.exs
@@ -38,4 +38,19 @@ defmodule Monero.WalletTest do
     expected = %{jsonrpc: "2.0", method: "open_wallet", params: params}
     assert expected == Wallet.open_wallet("test-wallet", "password").data
   end
+
+  test "transfer/3" do
+    dst = %{
+      address: "9wq792k9sxVZiLn66S3Qzv8QfmtcwkdXgM5cWGsXAPxoQeMQ79md51PLPCijvzk1iHbuHi91pws5B7iajTX9KTtJ4bh2tCh",
+      amount: 3_000_000_000_000
+    }
+    params = [payment_id: "test-payment", get_tx_key: true, priority: 1, do_not_relay: true, get_tx_hex: true]
+    expected_params =
+      params
+      |> Map.new()
+      |> Map.merge(%{destinations: [dst], mixin: 4, unlock_time: 60})
+
+    expected = %{jsonrpc: "2.0", method: "transfer", params: expected_params}
+    assert expected == Wallet.transfer([dst], 4, 60, params ++ [fake: "not-permitted"]).data
+  end
 end


### PR DESCRIPTION
Add 2 new calls:

- `Wallet.transfer/3`
- `Daemon.sendrawtransaction/1`

Add `build_opts` utility function to the `Wallet` module to construct permitted opts map